### PR TITLE
[BOJ] 1654. 랜선 자르기

### DIFF
--- a/남동우/BOJ1654.java
+++ b/남동우/BOJ1654.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ1654 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int k = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        List<Integer> list = makeList(br, k);
+        list.sort(Comparator.naturalOrder());
+
+        System.out.println(findMaxLine(list, n));
+    }
+    static List<Integer> makeList(BufferedReader br, int k) throws IOException{
+        List<Integer> list = new ArrayList<>();
+        for(int i = 0; i < k; i++){
+            int n = Integer.parseInt(br.readLine());
+            list.add(n);
+        }
+        return list;
+    }
+    static long findMaxLine(List<Integer> lineList, int n){
+
+        long left = lineList.get(0) / n > 0 ? lineList.get(0) / n : 1;
+        long right = lineList.get(lineList.size() - 1);
+        long answer = left;
+
+        while(left <= right){
+            long mid = (left + right) / 2;
+            if(isAvailable(lineList, mid, n)){
+                answer = mid;
+                left = mid + 1;
+            }else{
+                right = mid - 1;
+            }
+        }
+        return answer;
+    }
+    static boolean isAvailable(List<Integer> list, long length, int need){
+        int count = 0;
+        for(Integer lineLength : list){
+            count += (lineLength / length);
+        }
+        return count >= need;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1654 번, 랜선 자르기 문제를 해결합니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/f2c82de9-0c95-49c1-9019-1e068bd75f1b)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

구미로 오는 셔틀버스를 타고 오면서, 빠르게 해결해 보자 싶어서 코드를 빠르게 작성했지만, 싸피 캠퍼스에 도착할 때까지 반례를 찾지 못해 문제를 해결하지 못했었습니다.

문제를 보고, "이거 그냥 답을 기준으로, 이진탐색을 진행해 보면 문제를 풀 수 있겠는데?" 하고 생각하여, 문제에 접근했습니다. 그리고, 랜선의 길이에 예상 답(mid) 을 나눈 몫을 전부 카운팅하여, 필요한 것보다 더 많이 가지고 갔는지 체크하는 방식으로 이진탐색을 진행했습니다.

이번 문제에서 제가 반례를 찾으며 든 생각은 크게 두가지입니다.

1. 이진탐색에서 굳이 좁은 범위에서 문제를 해결할 필요가 있는가 하는 회의감? 이었습니다. 애초에 범위가 반씩 계속 줄어드는 마당에, 좁게 잡아도 많아야 두번에서 세번 정도의 탐색을 추가로 진행할 뿐인 것 같았습니다. 그래서, 정말 터무니없는 범위라면 모를까, 합당한 정도의 범위라면, 탐색 범위를 나름 크게 잡아도 괜찮겠다 하는 생각이 들었습니다.

2. 저는 문제를 혼자서 해결하지 못하고, 반례집을 찾아 보았습니다. 제가 간과한 점은, (left + right) / 2 를 진행할 때 , left + right 에서 int 범위 밖으로 오버플로우가 날 수 있다는 사실을 간과한 것입니다. 조건에, "랜선의 길이는 2^31 - 1 보다 작거나 같은 자연수이다" 라고 적혀 있습니다. 그렇다는 말은, 랜선의 길이를 정확히 Integer.MAX_VALUE 만큼 줄 수도 있다는 말도 됩니다. 저는 저 부분에서 실수하여, 문제를 해결하지 못했었습니다. 혹시나 문제를 보고, 연산 과정 중 오버플로우가 발생하지는 않는지 확인해야 한다는 교훈을 얻었습니다. 결국 저는 left, right, answer 를 저장하는 변수 모두를 long 으로 바꾸고 나서야, 문제를 최종적으로 해결할 수 있었습니다. 

생각해보면, 저 스스로 "이 문제는 이진탐색으로 풀었을 때 틀릴 수가 없는 문제야!" 하고 확신이 섰기 때문에, 스스로 간과하고 있는 반례를 찾으면 문제를 해결할 수 있다고 생각하고 문제에 마저 접근했습니다. 

앞으로 문제를 풀 때, 특히 Java 로 문제를 풀 때 overflow 가 발생할 수 있다는 사실을 충분히 고려해 문제를 해결해야 한다는 교훈을 얻어가는 문제였습니다!




