### PR TITLE
[BOJ] 2784. 가로 세로 퍼즐

### DIFF
--- a/BOJ2784.java
+++ b/BOJ2784.java
@@ -1,0 +1,165 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ2784 {
+	static boolean isChecked;
+	static List<Integer[]> indexMatrix;
+	static Set<char[][]> mapList;
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		List<String> inputList = makeInputList(br);
+		mapList = new HashSet<>();
+		inputList.sort(Comparator.naturalOrder());
+		
+		dfs(inputList, new boolean[6], 0, 3);
+		if(mapList.size() == 0) {
+			System.out.println(0);
+			return;
+		}
+		
+		char[][] finalMap = null;
+		for(char[][] map : mapList) {
+			if(finalMap == null) {
+				finalMap = map;
+			}else {
+				finalMap = compareTwoMap(finalMap, map) ? finalMap : map;
+			}
+		}
+		
+		printWordMap(finalMap);
+	}
+	static boolean compareTwoMap(char[][] A, char[][] B) {
+		String buildA = makeString(A);
+		String buildB = makeString(B);
+		return buildA.compareTo(buildB) < 0;
+	}
+	static String makeString(char[][] map) {
+		StringBuilder builder = new StringBuilder();
+		for(int i = 0; i < 3; i++){
+			for(int j = 0; j < 3; j++) {
+				builder.append(map[i][j]);
+			}
+		}
+		return builder.toString();
+	}
+	static List<String> makeInputList(BufferedReader br) throws IOException{
+		List<String> list = new ArrayList<>();
+		for(int i = 0; i < 6; i++) {
+			list.add(br.readLine().trim());
+		}
+		
+		return list;
+	}
+	
+	static void dfs(List<String> inputList, boolean[] visited, int currentIndex, int count) {
+		if(count == 0) {
+			isChecked = checkAndPrintIfPositive(inputList, visited);
+			return;
+		}
+		
+		for(int i = currentIndex; i < 6; i++) {
+			visited[i] = true;
+			dfs(inputList, visited, i + 1, count - 1);
+			visited[i] = false;
+		}
+	}
+	static boolean checkAndPrintIfPositive(List<String> inputList, boolean[] visited) {
+		List<String> falseList = new ArrayList<>();
+		List<Integer> indexList = new ArrayList<>();
+		for(int i = 0; i < 6; i++) {
+			if(visited[i]) {
+				indexList.add(i);
+			}else {
+				falseList.add(inputList.get(i));	
+			}
+		}
+		
+		indexMatrix = new ArrayList<>();
+		setIndexMatrixByPermutation(indexList.toArray(new Integer[0]), 0, 3, 3);
+		for(int i = 0; i < indexMatrix.size(); i++) {
+			Integer[] indexArray = indexMatrix.get(i);
+			char[][] map = new char[3][3];
+			setWordMap(map, inputList, indexArray);
+
+			List<String> verticalWord = makeVerticalWord(map, indexArray);
+			
+			for(String falseWord : falseList) {
+				if(verticalWord.contains(falseWord)) {
+					verticalWord.remove(falseWord);
+				}else {
+					break;
+				}
+			}
+			
+			if(verticalWord.size() == 0 && !haveThisMap(map)) {
+				mapList.add(map);
+				return true;
+			}
+		}
+		return false;
+	}
+	static boolean haveThisMap(char[][] map) {
+		for(char[][] haveMap : mapList) {
+			if(isSame(haveMap, map)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	static boolean isSame(char[][] A, char[][] B) {
+		for(int i = 0; i < 3; i++) {
+			for(int j = 0; j < 3; j++) {
+				if(A[i][j] != B[i][j]) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+	static void setIndexMatrixByPermutation(Integer[] arr, int depth, int n, int r){
+		if(depth == r) {
+			indexMatrix.add(Arrays.stream(arr).toArray(Integer[]::new));
+			return;
+		}
+		
+		for(int i = depth; i < n ; i++) {
+			swap(arr, depth, i);
+			setIndexMatrixByPermutation(arr, depth + 1, n, r);
+			swap(arr, depth, i);
+		}
+	}
+	static void swap(Integer[] arr, int depth, int i) {
+		int temp = arr[depth];
+		arr[depth] = arr[i];
+		arr[i] = temp;
+	}
+	static List<String> makeVerticalWord(char[][] map, Integer[] indexArray){
+		List<String> verticalList = new ArrayList<>();
+
+		StringBuilder builder = new StringBuilder();
+		for(int x = 0; x < 3; x++) {
+			builder.delete(0, builder.length());
+			for(int y = 0; y < 3; y++) {
+				builder.append(map[y][x]);
+			}
+			verticalList.add(builder.toString());
+		}
+		return verticalList;
+	}
+	static void printWordMap(char[][] map) {
+		for(int i = 0; i < 3; i++) {
+			for(int j = 0; j < 3; j++) {
+				System.out.print(map[i][j]);
+			}
+			System.out.println();
+		}
+	}
+	static void setWordMap(char[][] map, List<String> wordList, Integer[] indexArray) {
+		for(int i = 0; i < 3; i++) {
+			char[] wordCharArray = wordList.get(indexArray[i]).toCharArray();
+			for(int j = 0; j < 3; j++) {
+				map[i][j] = wordCharArray[j];
+			}
+		}
+	}
+}

--- a/남동우/BOJ1654.java
+++ b/남동우/BOJ1654.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ1654 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int k = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        List<Integer> list = makeList(br, k);
+        list.sort(Comparator.naturalOrder());
+
+        System.out.println(findMaxLine(list, n));
+    }
+    static List<Integer> makeList(BufferedReader br, int k) throws IOException{
+        List<Integer> list = new ArrayList<>();
+        for(int i = 0; i < k; i++){
+            int n = Integer.parseInt(br.readLine());
+            list.add(n);
+        }
+        return list;
+    }
+    static long findMaxLine(List<Integer> lineList, int n){
+
+        long left = lineList.get(0) / n > 0 ? lineList.get(0) / n : 1;
+        long right = lineList.get(lineList.size() - 1);
+        long answer = left;
+
+        while(left <= right){
+            long mid = (left + right) / 2;
+            if(isAvailable(lineList, mid, n)){
+                answer = mid;
+                left = mid + 1;
+            }else{
+                right = mid - 1;
+            }
+        }
+        return answer;
+    }
+    static boolean isAvailable(List<Integer> list, long length, int need){
+        int count = 0;
+        for(Integer lineLength : list){
+            count += (lineLength / length);
+        }
+        return count >= need;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 2784 번, 가로 세로 퍼즐 문제를 해결합니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/c6d7b620-8bea-4036-a1ff-6b48ac876223)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음 문제를 마주하고 나서, 문제를 어떻게 해결해야 할지 마땅한 방법이 생각나지 않다가, 6개 줄에 3 by 3 정도밖에 입력값이 주어지지 않았다는 것을 확인하자마자 이 문제가 단순히 "빡구현" 으로 풀 수 있다는 사실을 발견했습니다. 통상적으로, 프로그램에서 1억번 연산할 때마다 1초가 걸린다고 합니다. 하지만, 우리가 신경써야 할 입력값의 크기는 6개 정도가 다입니다. 심지어 이차원 배열은 3 by 3 크기가 다입니다. 정말 말도 안되게 구현을 하지 않는 이상, 9개 채워서 보는데 1억번의 연산을 하는 것이 거의 불가능한 수준이 될 것입니다. 

저는, 예제로 입력받는 6개 단어 중, 3개를 조합으로 뽑은 뒤, 가로 부분에 배치하기로 했습니다. 이후, 그 단어들 중에서도 위치가 바뀌면 다른 퍼즐이 될 수 있기 때문에 거기서 한번 더 순열으로 단어를 배치하고 그 결과로 나오는 세로 단어와 기존의 남은 단어들을 모두 비교했습니다. 

말만 해서는 쉬워 보였지만, 생각보다 구현해야 하는 양이 많았습니다. 하지만, 일단 "이거는 구현만 똑바로 하면 무조건 되겠다!" 하는 마인드로 문제에 도전했고, 244ms 정도로 생각보다 많이 걸린 실행 시간이 나왔지만 결국 해결했습니다. 

오랜만에 "구현" 문제를 만나서 좀 애먹었습니다. 심지어, 조합 이후 순열을 가져갈 것이 아니라 처음부터 순열을 활용해 문제를 해결했다면, 조금 더 문제를 깔끔하고 빠르게 풀 수 있었을 것 같습니다. 그리고 순열을 구현하는 데 있어 아직 스스로 익숙치 않다는 것을 깨달았습니다. python 에서는 itertools 로 그냥 구현하면 되니까, 여기에 익숙해서 그런 것 같습니다. 순열 문제를 더 풀고, 익숙해져야 하겠습니다.

오늘 문제도 나름 애먹이는 문제가 아닐 수 없습니다...! 그래도 이렇게 한 발짝 더 고수의 길로? 나아가는 것 같습니다 ^^