### PR TITLE
[BOJ] 2002. 추월

### DIFF
--- a/황윤정/BOJ2002.java
+++ b/황윤정/BOJ2002.java
@@ -1,0 +1,28 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ2002 {
+	static int N, result;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		HashMap<String, Integer> inOrder = new HashMap<>();
+		N = Integer.parseInt(br.readLine());
+		for(int i=0; i<N; i++) {
+			inOrder.put(br.readLine(),i); // 터널에 들어간 차, 들어온 순서 저장
+		}
+		int[] outOrder = new int[N];
+		for(int i=0; i<N; i++) {
+			String car = br.readLine();
+			outOrder[i] = inOrder.get(car); // i는 나온 순서
+		}
+		for(int i=0; i<N-1; i++) {
+			for(int j=i+1; j<N; j++) {
+				if(outOrder[i] > outOrder[j]) { // 늦게 나온 차들보다 들어온 순서가 늦다면
+					result++; // 추월
+					break;
+				}
+			}
+		}
+		System.out.println(result);
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 2002번. 추월 문제를 해결하였습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/79037963/a4a7804c-b524-469b-b80e-475a63bb9fe9)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에는 들어온 위치보다 나온 위치가 더 작다면(빠르다면) 추월한 것으로 처리했다가 틀렸습니다.
아무래도 들어오기 전 후의 차의 위치를 비교하기보다는, 터널을 지나간 차들 간의 비교가 필요하다고 생각했습니다.

1. Map에 차량번호, 들어온 순서를 저장합니다.
2. 터널을 나온 순서대로 배열에 차가 들어온 순서(Map에서 가져오기)를 저장해줍니다.
3. 나중에 나온 차보다 더 늦게 들어왔다면 추월한 것으로 처리합니다.

Map을 별로 사용 안했는데 이번에 Map을 사용하여 편하게 문제를 풀었습니다.
앞으로도 Map을 적극 이용해보려고 합니다.