### PR TITLE
[BOJ] 2468. 안전 영역

### DIFF
--- a/남동우/BOJ2468.java
+++ b/남동우/BOJ2468.java
@@ -1,0 +1,76 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ2468 {
+    static List<List<Integer>> direction = List.of(List.of(1,0), List.of(0,1),
+            List.of(-1,0), List.of(0,-1));
+    static int maxHeight;
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] matrix = makeMatrix(br, n);
+        Queue<List<Integer>> queue = new ArrayDeque<>();
+        Set<List<Integer>> visitedSet = new HashSet<>();
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < maxHeight; i++) {
+            int value = getCountOfLand(queue, visitedSet, matrix, i);
+            if (max < value) {
+                max = value;
+            }
+            visitedSet.clear();
+        }
+        System.out.println(max);
+    }
+
+    static int[][] makeMatrix(BufferedReader br, int size) throws IOException {
+        maxHeight = Integer.MIN_VALUE;
+        int[][] matrix = new int[size][size];
+        for (int i = 0; i < size; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < size; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+                if (maxHeight < matrix[i][j]) {
+                    maxHeight = matrix[i][j];
+                }
+            }
+        }
+        return matrix;
+    }
+
+    static int getCountOfLand(Queue<List<Integer>> queue, Set<List<Integer>> visitedSet, int[][] matrix, int n) {
+
+        int count = 0;
+        for(int y = 0; y < matrix.length; y++) {
+            for(int x = 0; x < matrix[0].length; x++) {
+                if(matrix[y][x] > n && !visitedSet.contains(Arrays.asList(x,y))) {
+                    bfs(queue, visitedSet, x, y, matrix, n);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    static void bfs(Queue<List<Integer>> queue, Set<List<Integer>> visitedSet, int x, int y, int[][] matrix, int n) {
+        queue.add(List.of(x,y));
+
+        while(!queue.isEmpty()) {
+            List<Integer> element = queue.remove();
+            int elementX = element.get(0);
+            int elementY = element.get(1);
+
+            for(int i = 0; i < 4; i++) {
+                int nextX = elementX + direction.get(i).get(0);
+                int nextY = elementY + direction.get(i).get(1);
+                List<Integer> point = List.of(nextX, nextY);
+                if(!visitedSet.contains(point) && !queue.contains(point) && canGo(nextX, nextY, matrix) && matrix[nextY][nextX] > n) {
+                    queue.add(point);
+                    visitedSet.add(point);
+                }
+            }
+        }
+    }
+    static boolean canGo(int x, int y, int[][] matrix) {
+        return (0 <= x && x < matrix[0].length) && (0 <= y && y < matrix.length);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 2468번, 안전 영역 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/74ca67bb-04b4-4ec3-95ad-af29ce74a517)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
메모리 초과 이슈로 엄청엄청엄청 고통받았던 문제입니다. 솔직히 하다하다 안되어서, Java 11 버전에 있는 List.of() 메소드까지 꺼내고 나서야 문제가 해결되었던 문제입니다. 아마 Java 8 버전에서는 제가 문제를 해결하지 못했을 것 같아요... ㅎㅎ

### 개인적인 고찰 : Arrays.asList() (Java 1.8) vs List.of() ( Java 11 )

기본적으로 이 문제가 BFS 로 풀릴 수 있는 문제라고 생각하고 문제에 접근했습니다,,,만, 지속적인 메모리 초과가 발생했습니다. 계속 메모리를 아낄 수 있는 코드로 리팩토링을 진행했고, BFS 상의 제 코드에서 문제를 발견해 고치기까지 했습니다. 기존의 제 방식은, BFS 로 노드 방문 시 방문 여부를 true로 바꿔 주었지만, 알고 보니 Queue 에 삽입할 때 바꿔 주었어야 했던 것입니다. 

그렇게 코드를 개선했음에도 불구하고, 여전히 메모리 초과가 발생했습니다. 이쯤 되면 Arrays.asList() 를 의심하지 않을 수 없습니다. Arrays.asList() 코드를 뜯어보았습니다.

![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/fc3f7ddd-6f82-479d-b470-fb766afd5492)

![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/118c0e61-260f-4e61-9c14-0cf265a63f46)

Arrays.asList() 는 ArrayList 를 돌려주는데, 알고 보니 이 ArrayList 는 Arrays.class 내의 private static class 로 되어 있는 class 입니다.

이 ArrayList 는, AbstractList() class 를 부모 클래스로 상속받는 자식 클래스이지만, add() 와 remove() 가 구현되어 있지 않은 클래스입니다. 그럼에도 불구하고, AbstractList 내의 add() 와 remove() 는 abstract class로 되어 있지 않습니다. 

더 궁금해져서, Arrays.asList() 와 List.of() 를 비교해 둔 문서들을 찾아보았습니다. 

+ Arrays.asList() : 
반 불변 객체. add() 와 delete() 는 구현되어 있지 않습니다. AbstractList 를 상속받기 때문에, List Interface 를 implement 한 것과 다를 바는 없습니다. 그래서, Arrays.asList() 를 호출한 후 add, delete 메소드를 호출하면  하지만, set(int index, E value) 는 구현되어 있어서, 완전 불변인 객체는 아닌 것입니다. 

그리고, Arrays.asList() 는, 가변 인자로 parameter 를 받습니다. 그런데, 가변 인자로 parameter 로 받으면, 그 내부에서 배열이 생기게 되고, Arrays.asList() 내에서 값을 수정한다면 해당 배열에서도 값이 바뀌는 식이라고 합니다. 

+ List.of() :
완전 불변 객체. add, delete, set 모든 것이 다 실행 불가능합니다. 하지만, 찾아본 결과, 완전 불변인 객체는 Caching 에서 유리한 고지를 가지고 갈 수 있다고 합니다. 그래서, 중복되는 배열이 생기지 않더라도, 메모리 퍼포먼스에서 유리하다고 합니다. 

구현체를 뜯어 보았다. List.of() 메소드가 두 개까지의 파라미터만 가질 경우, ImmutableCollection.List12<> 의 static final class 를 가진다고 합니다. 아마 final 키워드 와 Caching 이 모종의 연관성을 가질 것 같기는 합니다.

Caching 과 메모리가 어떤 연관이 있는지, 그리고 List.of 가 왜 캐싱에서 유리한지 추가적으로 계속 적어 보겠습니다! 기다리고 계신 분들이 있을 것 같아 일단 이까지 줄여 보겠습니다 ㅎㅎ

뭔가 시원하게 머릿속에서 정리된 것 같지는 않습니다. 추후, 메모리 퍼포먼스를 계산해 주는 기능으로 엄청 큰 데이터를 한번 넣어 보아야 할 것 같습니다. 그리고,  