### PR TITLE
[BOJ] 11060. 점프 점프

### DIFF
--- a/여아정/boj_11060.java
+++ b/여아정/boj_11060.java
@@ -1,0 +1,59 @@
+package cocodingding;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_11060 {
+	static int[]input;
+	static Queue<Integer>q;
+	static boolean[] chk;
+	static int n, cnt;
+	static int[]len;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+		n=Integer.parseInt(br.readLine());
+		q=new ArrayDeque<>();
+		input=new int[n];
+		chk=new boolean[n];
+		len=new int[n];
+		StringTokenizer st=new StringTokenizer(br.readLine());
+		
+		for(int i=0;i<n;i++) {
+			input[i]=Integer.parseInt(st.nextToken());
+		}
+		cnt=bfs();
+		System.out.println(cnt);
+	}
+
+	public static int bfs() {
+		chk[0]=true;
+		cnt= 0;
+		q.offer(0);
+		
+		while(!q.isEmpty()) {
+			int size=q.size();
+			while(--size>=0) {
+				int now=q.poll();
+				if(now==input.length-1) {
+					return cnt;
+				}
+				for(int i=now+1;i<=input[now]+now && i<n; i++) {
+					if(chk[i]==false) {
+						chk[i]=true;
+						q.offer(i);
+					}
+				}
+			}
+			cnt++;
+		}
+		
+		return -1;
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 11060 점프점프 문제 마무리했습니다.


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/108220312/78ac536f-715b-452a-95ff-6c2e47d8f69d)



## 📝 Review Note
처음에 스터디 모였을 때 문제를 마무리를 못했습니다.
문제를 접근할 때  `BFS`를 이용하여 가장 먼저 결과 값에 도달하게 되면 그것이 최소 점프값 이라고 생각했습니다. 시간초과, 메모리 초과 등 을 여러번 당했습니다....
그 문제를 오랜시간 확인을 했었는데 큐에는 값들이 잘 들어갔으나 `poll()` 하면서 한 깊이를 체크하는 부분에서 문제가 발생했습니다. 저는 해당 노드의 자식 부분 까지만 체크 후 `cnt++`를 원했는데 `size`가 계속 `Queue`에 다음 값을 넣으면서 `size++`를 해주다 보니 제대로 카운트가 되지 않았습니다.  이 부분을 수정하기 위해 많은 시간이 들었습니다. 결국 초기 노드의 `size=queue.size()`를 해주어서 그 만큼 반복 돌기를 여러 번 하는 것으로 `cnt`를 측정할 수 있었습니다.
도움을 주신 분들 감사합니다.....🙇‍♀️🫶