### PR TITLE
[BOJ]1080. 행렬 + 11060 점프 점프 🦘

### DIFF
--- a/soomin_kim/BOJ_S1080.java
+++ b/soomin_kim/BOJ_S1080.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_S1080 {
+    static int[][] arrayA;
+    static int[][] arrayB;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        arrayA = new int[n][m];
+        arrayB = new int[n][m];
+        // A 배열
+        for(int i = 0; i<n; i++){
+            String[] line = br.readLine().split("");
+            for(int j = 0; j<m; j++){
+                arrayA[i][j] = Integer.parseInt(line[j]);
+            }
+        }
+        // B 배열
+        for(int i = 0; i<n; i++){
+            String[] line = br.readLine().split("");
+            for(int j = 0; j<m; j++){
+                arrayB[i][j] = Integer.parseInt(line[j]);
+            }
+        }
+
+       int count = 0;
+        //3*3 탐색 시작
+        for(int i = 0; i < n-2; i++){
+            for(int j = 0; j < m-2; j++) {
+                if(arrayA[i][j] != arrayB[i][j]) { // 다르면 바꿔준다.
+                    change(i, j);
+                    count++;
+                }
+            }
+        }
+
+        for(int i = 0; i<n; i++){
+            for(int j = 0; j<m; j++){
+                if(arrayA[i][j] == arrayB[i][j]) continue;
+                System.out.println(-1);
+                return;
+            }
+        }
+        System.out.println(count);
+    }
+    
+    //3*3 크기만큼 비트 뒤집기
+    public static void change(int x, int y){
+        for(int i = x; i<x+3; i++) for (int j = y; j < y + 3; j++) arrayA[i][j] = arrayA[i][j] ^ 1;
+    }
+}

--- a/soomin_kim/BOJ_S11060.java
+++ b/soomin_kim/BOJ_S11060.java
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_S11060 {
+    static int n;
+    static int[] miro;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        miro = new int[n];
+        for (int i = 0; i < n; i++) {
+            miro[i] = Integer.parseInt(st.nextToken());
+        }
+
+        System.out.println(bfs(0));
+    }
+
+
+    public static int bfs(int index) {
+        //int min = 1001;
+        boolean[] visited = new boolean[n];
+        int depth = 0; //횟수
+        Queue<int[]> q = new LinkedList<>();
+        q.add(new int[]{index, depth});
+        visited[index] = true;
+        while (!q.isEmpty()) {
+
+            int[] current = q.poll();
+            int currentIndex = current[0];
+            int currentJump = miro[current[0]];
+            depth = current[1];
+            //visited[currentIndex] = true;
+
+            if (currentIndex == n - 1) { //배열의 끝까지 점프했다면 횟수 비교!
+                return depth;
+            }
+
+            if (currentJump == 0) { // 아무곳으로도 못 감
+                continue;
+            }
+
+            for (int i = 1; i <= currentJump; i++) {
+                int nextIndex = currentIndex + i;
+                if (nextIndex >= n || visited[nextIndex]) continue;
+                visited[nextIndex] = true;
+                q.add(new int[]{nextIndex, depth + 1});
+            }
+        }
+        return -1;
+    }
+}
+
+


### PR DESCRIPTION
## 👩‍💻 Contents
백준 1080번 행렬을 풀었습니다.


## 📱 Screenshot
캡쳐도구가 이상해졌습니다. 
* 메모리 12680KB
* 시간 116ms 


## 📝 Review Note

완전탐색으로 풀었습니다. A 배열을 돌면서 B 배열과 다른 부분이 있다면 해당 좌표부터 3*3 크기를 돌면서 비트 상태를 바꿔줍니다. 

요새 자주하는 실수가 로컬변수로 선언했다가 전역변수로 바꿀 때 로컬 변수로 선언했던 부분을 수정하지 않아서 계속 오류가 나는데 앞으로는 코드를 짤 때부터 필요한 부분은 전역변수로 바로 둘 수 있도록 생각을 하면서 짜야겠다는 다짐을 했습니다.

고생하셨습니다~~

---
추가로 수요일에 모여서 풀었던 11060 점프점프도 올립니다!

간단하게 설명을 해보자면 저는 bfs로 풀었습니다. 점프로 갈 수 있는 곳을 queue에 넣고 그 층을 모두 탐색하면 depth를 증가시켜 
`층 == 점프횟수`로 풀었습니다!

bfs 문제를 더 많이 풀어봐야겠습니다 ㅜ 층을 증가시킬 방법을 찾지 못해서 많이 헤매고 도움도 많이 받았습니다. 감사합니다 ;)


