### PR TITLE
[BOJ] 5397. 키로거

### DIFF
--- a/황윤정/BOJ5397.java
+++ b/황윤정/BOJ5397.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ5397 {
+	static int T;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		T = Integer.parseInt(br.readLine());
+		for(int t=0; t<T; t++) {
+			char[] input = br.readLine().toCharArray();
+			Deque<Character> deque = new ArrayDeque<>(); // 데이터 담는 덱 (메인 저장)
+			Stack<Character> tmp = new Stack<>(); // 커서 옮길 때 최근 값 이동하는 임시 스택
+			for(int i=0; i<input.length; i++) {
+				if(input[i] == '<') { // 커서를 왼쪽으로 옮길 때
+					if(deque.size() > 0) {
+						tmp.push(deque.pollLast()); // 이전 값이 덱의 최상위에 있도록 커서 밖의 값을 tmp로
+					}
+				}
+				else if(input[i] == '>') { // 커서를 오른쪽으로 옮길 때
+					if(tmp.size() > 0) {
+						deque.offerLast(tmp.pop()); // 이전에 커서이동으로 tmp에 옮겨둔 값 있으면 덱으로 이동
+					}
+				}
+				else if(input[i] == '-') { // 현재 커서에 있는 값 제거
+					if(deque.size() > 0) {
+						deque.pollLast(); // 덱에 마지막으로 들어온 값 삭제 
+					}
+				}
+				else { // 대소문자 추가
+					deque.offerLast(input[i]); // 덱에 데이터 추가
+				}
+			}
+			while(!tmp.isEmpty()) {
+				deque.offerLast(tmp.pop()); // 왼쪽 커서 이동으로 tmp에 옮겨둔 값을 모두 덱으로 합치기
+			}
+			while(!deque.isEmpty()) {
+				sb.append(deque.pollFirst()); // 덱에 처음 들어온 수부터 내보내기
+			}
+			sb.append("\n");
+		}
+		System.out.println(sb.toString());
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 5397번 키로거 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/79037963/ec4a9cc1-41c5-4a0f-9976-480026e8ef09)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에는 LinkedList로 문제를 쉽게 해결할 수 있을 것이라 생각했습니다.
커서를 나타내는 변수를 하나 만들어서 문자의 추가나 커서의 변동을 관리하며 LinkedList에 값을 추가하였습니다.
하지만 Runtime Exception이 여러 번 발생하였고, 삭제에서 생기는 오류를 겨우 찾아서 해결하고나니 시간초과가 났습니다.
연결리스트 특성상 제가 원하는 위치에 추가, 삭제를 하기 위해서는
순차적으로 인덱스에 접근하므로 결국 O(N)이더군요

그래서 다른 방법을 생각하였고 스택을 2개 이용하기로 했습니다.
2개 사용하는 이유는 스택 1개에 데이터 추가를 하며 커서의 이동에 따라 현재 커서가 위치하는 곳을 스택 최상단에 있도록 하기 위해서 입니다. 원래 위에 있던 데이터는 나머지 스택에 옮겨가면서 커서 관리를 합니다.
하지만 마지막에 모든 데이터를 뽑아내서 출력할 때 스택만 2개 쓰게되면, 연산이 끝났을 때 위쪽 데이터를 저장하는 tmp 스택으로 데이터를 모두 옮기고 거기서 pop 하며 위쪽부터 출력해야합니다. 고로 편의성을 생각하여 데이터를 주로 저장하는 곳은 덱, 커서에 움직임에 따라 잠시 옮겨두는 곳은 스택을 사용하였습니다.
덱을 이용하면 pollFirst() 같은 연산을 이용하여 먼저 들어온 수부터 바로 내보낼 수 있습니다.

위를 이용하여 구현한 내용을 보자면
왼쪽으로 커서를 이동할 때 커서보다 밖에 있는 값은 모두 덱에서 제거하여 스택으로 옮기고 
오른쪽으로 커서를 이동할 때 이동할 문자가 있다면 스택에서 옮겨오고, 없으면 무시합니다
제거는 덱에서 데이터를 삭제하고, 추가는 덱에 데이터를 추가합니다.

간단한 문제라고 생각했는데 자료구조에 대해 제법 많이 생각했던 문제였습니다.