### PR TITLE
[PG] 12913. 땅따먹기

### DIFF
--- a/이수민/PG_12913.java
+++ b/이수민/PG_12913.java
@@ -1,0 +1,23 @@
+public class PG_12913 {
+    int solution(int[][] land) {
+        int answer = 0;
+
+        int N = land.length;
+
+        // 현재 보고 있는 각 열들은
+        for(int i=1; i<N; i++){
+            // 이전 행의 열은 현재 행의 열의 인덱스와 같지 않아야 하므로 최대값 과정에서 제외
+            land[i][0] += Math.max(land[i-1][1], Math.max(land[i-1][2], land[i-1][3]));
+            land[i][1] += Math.max(land[i-1][0], Math.max(land[i-1][2], land[i-1][3]));
+            land[i][2] += Math.max(land[i-1][0], Math.max(land[i-1][1], land[i-1][3]));
+            land[i][3] += Math.max(land[i-1][0], Math.max(land[i-1][1], land[i-1][2]));
+        }
+
+        // 마지막 행 중 최댓값이 이 문제의 답
+        for (int i=0; i<4; i++){
+            answer = Math.max(land[N-1][i], answer);
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
프로그래머스 12913번 땅따먹기 문제를 풀었습니다.


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/c7672715-7463-4f13-919d-be8d8df05a7f)

## 📝 Review Note
처음에 문제를 접근할 때는 따로 land의 내용을 저장할 배열을 만들었습니다. 문제의 조건도 제대로 보지 않아서 4열로 고정된 것을 생각하지 못해 HashMap에 값과 인덱스를 저장하고 최댓값을 찾을 수 있도록 정렬하여 따로 저장한 배열에 더하는 식으로 생각했습니다. 이 풀이는 하나 밖에 없는 예시는 통과했으나, 채점에서 모든 테스트 케이스를 틀리고 시간초과를 가져왔습니다..ㅎ

이후 문제를 다시 생각하여, 주어진 land 배열의 길이만큼 순회하여 land 배열의 값 자체를 갱신하는 풀이를 작성했습니다.
현재 보고 있는 열이 가질 수 있는 최댓값은 이전 행의 열들 중 최댓값에 자신의 값을 더하는 것입니다. (단, 이전 행의 열은 현재 행의 열의 인덱스와 같지 않아야 하므로 ```Math.max()``` 과정에서 제외했습니다) 

위와 같게 풀이 노선을 변경하니 생각보다는 간단하게 해결 가능했습니다..^^

문제를 제대로 읽고 DP 문제를 좀 더 자주 접해서 문제 접근에 대한 시야를 넓혀야겠다고 느꼈습니다.
