### PR TITLE
[BOJ] 2841. 외계인의 기타 연주

### DIFF
--- a/남동우/BOJ2841.java
+++ b/남동우/BOJ2841.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ2841 {
+    static int count;
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        int n = Integer.parseInt(st.nextToken());
+        count = 0;
+
+        Map<Integer, Stack<Integer>> soundMap = new HashMap<>();
+      // 입력받는 소리를 해시맵을 통해 매핑합니다.
+
+        for(int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine()," ");
+            int prat = Integer.parseInt(st.nextToken());
+            int sound = Integer.parseInt(st.nextToken());
+          // 프랫과 소리를 입력받습니다. 
+          // 이후, map 에 prat 이 없다면, 스택을 새로 넣어 줍니다.
+
+            if(!soundMap.containsKey(prat)) {
+                soundMap.put(prat, new Stack<>());
+            }
+
+          // prat 을 가지고, soundMap 에서 stack 을 받아옵니다.
+          // 이후, 해당 스택의 맨 위가 sound 보다 작아지거나, 스택이 빌 때까지 stack 에서 위의 요소를 빼 줍니다.
+          // 물론, stack에서 맨 위를 뺄 때도, "손가락을 떼는" 행위이므로, 함수 내에서 count 를 증가시켜 줍니다.
+            Stack<Integer> stack = soundMap.get(prat);
+            modifyMap(stack, sound);
+
+          // 혹시 stack 이 비어 있지 않았으면서도, 스택의 맨 위가 sound 와 같으면 
+          // 새로 "손가락을 눌러 줄" 필요가 없습니다.
+            if(!stack.isEmpty() && stack.peek() == sound){
+                continue;
+            }
+
+          // 위의 if 문에 걸리지 않았다면, "손가락을 눌러 주어야" 합니다.
+          // 입력받은 prat 의 stack에 sound 를 추가해 줍니다.
+            count++;
+            stack.push(sound);
+        }
+
+        System.out.println(count);
+    }
+  // 스택이 비어 있지 않았으면서도, 스택의 맨 위가 sound 보다 크다면, 
+  // "손가락을 움직여 주어야" 합니다. count 를 1 증가시키고, stack에서 맨 위 요소를 빼 줍니다.
+    static void modifyMap(Stack<Integer> stack, int sound){
+        while(!stack.isEmpty() && stack.peek() > sound){
+            count++;
+            stack.pop();
+        }
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 2841번, 외계인의 기타 연주 문제를 해결합니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/44a5b3cf-5a6e-4fe2-8899-3e635403d5d3)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
생각보다 멜로디에 포함되어 있는 음의 수가 컸습니다. 1억 번 연산 기준인데, 50만입니다. 그렇다는 말은, 한 음을 연산하는 데 200번 정도 연산을 할 수 있다는 의미가 됩니다. 그런데 문제를 읽다 보니, "이거 그냥 프렛 하나를 기준으로 하는 스택을 만들면 해결할 수 있지 않을까?" 하는 생각이 들었습니다. 자료 구조를 통해 문제를 해결할 수 있다면, 이진 탐색을 해야 하는 문제가 아닌 이상 어지간하면 해결할 수 있습니다. 그래서, 해시맵에다 프렛을 기준으로 Stack 을 value 로 넣어 준 뒤, 프렛과 음을 받을 때마다 스택에서 sound 보다 큰 값을 모두 빼 준 뒤 sound 를 넣는 식으로 문제를 해결했습니다. 물론, sound 와 stack 의 맨 윗 값이 같다면 굳이 추가적으로 count 를 늘려 주지는 않았습니다. 

나름 간단한 문제였지만, 5시 30분부터 문제를 풀기 시작해 저녁을 먹고 난 뒤까지 시간을 끌어 나름 아쉬웠습니다.

