### PR TITLE
[BOJ] 1890. 점프

### DIFF
--- a/남동우/BOJ1890.java
+++ b/남동우/BOJ1890.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ1890 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		
+		int[][] matrix = makeMatrix(br, n); // 입력 2차원 배열을 받아 줍니다.
+		long[][] count = new long[matrix.length][matrix[0].length]; // DP 를 이용할 것입니다. 먼저, memoization 을 해 줄 2차원 배열을 만듭니다.
+		count[0][0] = 1; // 시작점을 갈 수 있는 경우의 수를 1로 초기화 해 줍니다.
+    // 여기에서, "갈 수 있는 경우의 수가 2^64 - 1 보다 작거나 같다" 라고 하였으므로, long 2차원 배열을 이용합니다. 
+		System.out.println(getCount(matrix, count)); // 결과값을 출력합니다. 
+	}
+	static long getCount(int[][] matrix, long[][] count) {
+		for(int y = 0; y < matrix.length; y++) {
+			for(int x = 0; x < matrix[0].length; x++) {
+        // 2차원 배열을 2중 for 문을 돌며 순회합니다. 
+        // matrix[y][x] 가 자주 쓰일 것 같아, value 로 만들어 주고, 값이 0 이라면 다음 값을 순회합니다.
+				int value = matrix[y][x];
+				if(value == 0) {
+					continue;
+				}
+
+        // value 가 0이 아니라면, 해당 자리에서 value 를 더한 만큼 오른쪽과 아래로 이동할 수 있습니다.
+        // 오른쪽 과 아래 위치가 이차원 배열에서 벗어나는지 아닌지 파악하고, 이차원 배열에서 벗어나지 않는다면
+        // count 에 기록해 줍니다.
+				if(canGo(x + value, y, matrix)) {
+					count[y][x + value] += count[y][x];
+				}
+				if(canGo(x, y + value, matrix)) {
+					count[y + value][x] += count[y][x];
+				}
+			}
+		}
+		// 최종적으로 오른쪽 아래의 기록 값을 출력합니다.
+		return count[matrix.length - 1][matrix[0].length - 1];
+	}
+	static boolean canGo(int x, int y, int[][] matrix) {
+		return (0 <= x && x < matrix[0].length) && (0 <= y && y < matrix.length);
+	}
+	static int[][] makeMatrix(BufferedReader br, int size) throws IOException{
+		int[][] matrix = new int[size][size];
+		for(int y = 0; y < size; y++) {
+			StringTokenizer st = new StringTokenizer(br.readLine()," ");
+			for(int x = 0; x < size; x++) {
+				matrix[y][x] = Integer.parseInt(st.nextToken());
+			}
+		}
+		return matrix;
+ 	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1890번, 점프 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/40974cb1-8af4-4133-aeb4-43f285d1200c)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에는 이 문제가 BFS/DFS 문제라고 생각해, 문제에 접근했습니다. 하지만, 메모리 초과를 맞아 버렸습니다. 처음에는 단순히 "좌표 객체를 많이 만들어 주어서, 메모리 초과가 나는 것 같다" 고 생각했지만, 의심되는 부분들을 하나씩 해결해 메모리 최적화를 진행했습니다만, 결국 답 자체도 틀려버렸습니다. 곰곰히 고려해 보니, 중복되게 하지 않으려면 한번 Queue에 넣었던 것들을 다시 넣으면 안 되겠다고 생각해 문제에 접근했는데, 이 생각에서 반례가 나왔던 것입니다. 

곰곰히 생각해 보니, 어차피 count 를 세는 부분이었습니다. 그리고, 오른쪽과 아래로만 이동한다고 적혀 있었기 때문에, 2차원 배열을 돌면서 DP 방식으로 문제를 풀어나가면 어떨까 싶어 문제 풀이 방식을 바꿔보았습니다. (0,0) 에서 시작하여, 오른쪽 아래까지 이동한다면, 이미 왼쪽 위에서부터 내려온 것이기 때문에, 임의의 좌표(x,y) 를 고려하고 있을 때 이미 해당 점에 도달하기 위한 모든 경우의 수가 모여 있는 것입니다. 

이번 문제가 DP로 해결 가능한지 검증도 해 보았습니다. "임의의 점 (x,y) 기준으로, 어떻게든 왼쪽에서 도달하는 경우의 수와 위에서 도달하는 경우의 수가 최적화되어 완료되어 있다고 가정한다면, 해당 점 (x,y) 에 도달할 수 있는 경우의 수는, 왼쪽과 위에서 도달할 수 있는 경우의 수의 합입니다." 

 위의 결론이 성립하면, 자동으로  Bottom-Up 방식도 가능합니다. count 라는 2차원 배열을 만들어 놓고, 왼쪽 위 값을 1로 초기화한 후, matrix 2차원 배열을 순회합니다.  matrix[y][x] 가 0이라면, 그냥 그 지점을 통과하며, 아니라면, 오른쪽과 아래쪽으로 갈 수 있는 경우의 수 기록에 matrix[y][x] 까지 올 수 있는 경우의 수를 추가합니다. 물론, 이차원 배열의 범위를 벗어나지 않는다면 위의 작업을 수행하면 될 것입니다.

이런 문제가 코딩테스트에 나왔다고 생각하면, 한번 오싹한 경험일 것입니다. BFS/DFS 문제라고 바로 낚여(?) 문제에 접근했는데, 그냥 틀려 버리는 것입니다. 앞으로, BFS/DFS 문제처럼 보인다 할지라도, 한번은 DP를 더 의심해 보는 습관을 들여야 하겠습니다.
