### PR TITLE
[BOJ] 1890. 점프

### DIFF
--- a/황윤정/BOJ1890.java
+++ b/황윤정/BOJ1890.java
@@ -1,0 +1,38 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ1890 {
+    static int N;
+    static int[][] arr; // 거리 입력 받는 배열
+    static long[][] dp; // 경로 개수 배열
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+
+        arr = new int[N][N];
+        dp = new long[N][N];
+        for(int i=0; i<N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<N; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dp[0][0] = 1; // 시작점 방문
+        for(int i=0; i<N; i++) {
+            for(int j=0; j<N; j++) {
+                int dist = arr[i][j]; // 현재 칸에서 갈 수 있는 거리
+                if(dist == 0) // 목적지 도착
+                    break;
+                if(i+dist < N) { // 아래로 이동 가능하다면
+                    dp[i+dist][j] += dp[i][j]; // 이동할 칸에 경로 개수 더하기
+                }
+                if(j+dist < N) { // 오른쪽으로 이동 가능하다면
+                    dp[i][j+dist] += dp[i][j]; // 이동할 칸에 경로 개수 더하기
+                }
+            }
+        }
+        System.out.println(dp[N-1][N-1]); // 총 경로 개수 출력
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1890번 점프 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/79037963/145a1805-ca9c-41ae-8cb5-ab4934504019)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에는 bfs, dfs로 풀이했다가 메모리 초과와 시간초과가 나왔습니다.
중복되는 경로가 많다는걸 깨닫고 방문 배열을 써서 중복을 줄여보려다 실패하였습니다.
그래서 경로 개수를 누적해보려고 시도했습니다.
게임판의 크기는 최대 100*100 이니까 2차원 배열을 돌면서 점프할 수 있는 곳의 경로 개수를 누적하였고
배열의 가장 오른쪽 아래에서 저장된 경로의 개수를 출력하였습니다.

이번 문제는 하도 낚여서 강렬했습니다. 역시 dp는 어마어마하네요^^