### PR TITLE
[BOJ] 11501. 주식

### DIFF
--- a/이수민/BOJ_11501.java
+++ b/이수민/BOJ_11501.java
@@ -1,0 +1,36 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_11501 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = null;
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        for(int t=0; t<T; t++) {
+
+            int n = Integer.parseInt(br.readLine());
+            st = new StringTokenizer(br.readLine());
+            int[] days = new int[n];
+            for(int i=0; i<n; i++) days[i] = Integer.parseInt(st.nextToken());
+
+
+            int max=0; // 뒤에서 부터 주가의 최댓값이 저장됨
+            long profit=0; // 만들 수 있는 최대 이익
+
+            // 주가를 뒤에서 부터 차례대로 순회
+            for(int i=n-1; i>=0; i--) {
+                if (max < days[i]) { // 오늘의 주가가 이제까지 최댓값보다 크다면 갱신
+                    max = days[i];
+                }
+                else {
+                    // 오늘의 주가가 최댓값보다 작거나 같으면, 현재 이익에 더해줌
+                    profit += max-days[i];
+                }
+            }
+            sb.append(profit).append("\n");
+        }
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 11501번 주식 문제를 풀었습니다!


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/fc077c2c-b1e9-425a-80ec-cb96b90f96a7)


## 📝 Review Note
처음에는 주가가 올랐다가 내려가기 시작하기 직전인 변곡점에서 주식을 판다고 가정한 후 left, right의 두 포인터 변수를 두고 right을 변곡점으로, left는 right을 쫓아가면서 주식을 살 수 있도록 코드를 작성했습니다. 
하지만 이 방법은 2 3 2 4와 같은 형태에서 2에서 사서 3에서 팔고, 2에서 사서 4에서 팔기 때문에 최종적으로 2의 수익을 냅니다. 이 문제에서 요구하는 올바른 답은 2, 3, 2에서 사고 4에서 모든 주식을 팔아 최종적으로 5가 되어야 했습니다..! 

그래서 기존에 풀던 방식을 뒤집어서 마지막 날부터 순회하며 (최대 이익을 만들 수 있는 주가의) 최댓값을 찾고 그 최댓값을 비교할 수 있도록 했습니다. 주가의 최댓값보다 현재 값이 더 크면 최댓값을 갱신하고, 현재 값이 최댓값보다 작거나 같으면 ```최댓값-주가```를 구하여 이익에 더해 주는 방식으로 풀었습니다.

문제의 반례를 떠올리지 못해서 질문 게시판의 힘을 많이 빌렸는데 좀 더 꼼꼼하게 문제를 생각할 수 있도록 해야겠습니다.