### PR TITLE
[BOJ] 1446. 지름길

### DIFF
--- a/남동우/BOJ1446.java
+++ b/남동우/BOJ1446.java
@@ -1,0 +1,78 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ1446 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+        
+        int n = Integer.parseInt(st.nextToken());
+        int d = Integer.parseInt(st.nextToken());
+        
+        Map<Integer, Map<Integer, Integer>> map = makeMap(br, n, d); // 입력으로부터, "유효한" 지름길 을 받아옵니다.
+        
+        System.out.println(getAnswer(map,d)); // 지름길로부터 도출되는 정답을 출력합니다.
+    }
+    static int getAnswer(Map<Integer, Map<Integer, Integer>> map, int dest) {
+    // distance int array 를 초기화하고, 지름길을 타지 않았다면 가야 하는 distance 정보를 입력해 줍니다.
+        int[] distance = new int[dest + 1]; 
+        for(int i = 1; i <= dest; i++) {
+            distance[i] = i;
+        }
+
+    // i = 0 부터 dest 지점까지 순차적으로 탐색해 줍니다. 어차피 d <= 10,000 이기 때문에, 시간초과가 나지 않을 것입니다.
+        for(int i = 0; i <= dest; i++) {
+            if(i >= 1) {
+        // 현재 보고 있는 지점까지 가야 하는 거리가, 이전 지점 + 1 보다 더 멀다면 이전 지점 + 1 으로 업데이트 합니다.
+        // 지름길로 인해, 현재 보고 있는 지점이 지름길로 인해 최소거리가 더 짧아졌는지 비교하는 것입니다.
+                distance[i] = Math.min(distance[i], distance[i-1] + 1);
+            }
+
+      // distance[i] 가 업데이트되고 난 후, 그 지점을 start 로 하는 지름길이 있는지 체크하고 start 뒤의 지점에서의
+      // distance 를 업데이트합니다.
+            if(map.containsKey(i)) {
+                for(Integer toGo : map.get(i).keySet()) {
+          // distance[toGo] 의 현재 값과, 지름길로 인해 더 짧아진 값을 비교해 더 최소값을 업데이트 합니다.
+                    distance[toGo] = Math.min(distance[toGo], distance[i] + map.get(i).get(toGo));
+                }
+            }
+        }
+
+    // 마지막으로 도출된 distance 최종 지점을 돌려줍니다.
+        return distance[dest];
+    }
+
+  // start, end, value 를 입력받고, 지름길을 타지 않는 길보다 더 짧으면서 범위 밖으로 나가지 않을 때만 Map 에다 
+  // 저장해서 최종적으로 Map 형태로 돌려주는 method 입니다.
+    static Map<Integer, Map<Integer, Integer>> makeMap(BufferedReader br, int size, int max) throws IOException{
+        Map<Integer, Map<Integer, Integer>> map = new HashMap<Integer, Map<Integer,Integer>>();
+        
+        for(int i = 0; i < size; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine()," ");
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            int value = Integer.parseInt(st.nextToken());
+          // start, end, value 를 입력받습니다.
+
+          // 도착 지점보다 end 가 더 뒤에 있거나, 지름길을 타는것보다 원래 길로 가는 것이 더 빠르다면,
+          // Map 에다 저장하지 않습니다.
+            if(end > max || value >= (end - start)) {
+                continue;
+            }
+
+          // map 이 start 를 key 로 가지지 않을 때, start 를 key 로, value 를 HashMap 으로 하는
+          // 구성을 map 에 넣어 줍니다.
+            if(!map.containsKey(start)) {
+                map.put(start, new HashMap<>());
+            }
+
+          // start 를 key 로 하는 hashMap 이 end 를 포함하고 있지 않거나, 포함하고 있더라도
+          // 가지고 있는 값보다 value 가 더 작다면 start-end 를 키로 하는 값을 업데이트해 줍니다.
+            if(!map.get(start).containsKey(end) || map.get(start).get(end) > value) {
+                map.get(start).put(end, value);
+            }
+        }
+
+        return map;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1446번, 지름길 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/9bc66bca-efbe-4231-9d8f-c55eaca7ee0e)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

처음에 이 문제를 마주할 때는, 이 문제가 최소 거리를 구해야 하는 이슈 때문에 다익스트라 알고리즘으로 해결해야 하는 문제인 줄 알았습니다. 하지만, 문제를 곰곰히 보고 있다 보니, 단순히 한 방향으로만 갈 수 있는 점(역주행 불가), 지름길이 없어도 갈 수 있는 점, 그리고 결정적으로 도착점 D의 범위가 10,000 을 넘지 않는데 1초(1억번 연산) 가 주어진 점이 마음에 걸렸습니다.

그렇게, 다익스트라 알고리즘이 아니라고 생각하고 문제를 다시 마주했습니다. 그렇게 보고 나니, 단순히 0부터 d까지 최소거리 배열을 만들어 놓고, 0부터 d까지 순회하면서 최소거리를 업데이트 해 준다면 문제를 해결할 수 있을 것 같았습니다. 어차피 1만번 순회하며, 그 전(index - 1) 최소거리 + 1 과 현재 지름길로 업데이트 되어 있는 거리를 비교하면 원하는 지점(index) 까지의 최소거리를 구할 수 있는 것이었습니다. 

그리고 나서, 그 지점(index) 에서 시작하는 지름길들로 이후에 있는 지점의 당시의 최소 거리를 업데이트 해 줍니다. 이렇게 하면, 어차피 그 뒤에서 지름길을 타지 않고 도착하는 방법과 지름길을 타고 도착하는 방법 다 업데이트가 되며, 앞에서 처리된 지점들의 최종적인 최소 거리가 모두 업데이트 되니 상관이 없는 것이었습니다. 이렇게 이 문제를 해결할 수 있었고, 다행히 반례가 나오지 않았습니다. 

한 번 꽂히는 방법이라고 하더라도, 영 석연치 않고 시원하게 나오는 방법이 아니라면 한번 다른 방식으로도 즉석해서 고려해 볼 만한 것 같습니다. 
