### PR TITLE
[BOJ] 25186. INFP 두람

### DIFF
--- a/이수민/BOJ_25186.java
+++ b/이수민/BOJ_25186.java
@@ -1,0 +1,36 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_25186 {
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        boolean flag = true; // 겹치지 않고 옷을 입을 수 있는지
+        long total = 0; // 사진을 찍는 전체 인원 수
+        long[] d = new long[N]; // 옷 종류마다의 개수 보관
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for(int i=0; i<N; i++) {
+            d[i] = Integer.parseInt(st.nextToken());
+            total += d[i];
+        }
+
+        // 한 명이면 겹칠 일 없으므로 happy~^^
+        if (total == 1) {
+            System.out.println("Happy");
+            return;
+        }
+
+        for(long i: d) {
+            if (total < i*2) { // 각 옷 종류가 전체 인원 수의 반을 넘으면, 겹치게 됨
+                flag = false;
+                break;
+            }
+        }
+
+        System.out.println(flag? "Happy" : "Unhappy");
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 25186번 INFP 두람 문제를 풀었습니다.

## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/e6513635-fbe8-4e2d-af52-e114af4c3e2d)


## 📝 Review Note
문제를 읽어보니 옛날,, 그,, 확통 과목 생각이 났습니다. 완탐 같은 알고리즘을 고려하지 않고 바로 경우의 수를 고려했습니다. ```옷의 종류의 총 합=사람의 수```였기 때문에 옷의 종류마다 사람의 수의 반을 넘지 않으면 happy고 그렇지 않으면 unhappy라고 설정했습니다. 이렇게 정하고 풀었음에도 여러 번 틀렸는데, 틀린 이유는 다음과 같습니다.
1. 사람이 한 명일 때의 경우를 고려하지 않았음.
	- 이런 엣지 케이스를 바로 알았으면 좋겠지만 질문 게시판을 보고 알았습니다.
2. 전체 사람 수와 현재 옷 종류의 수를 비교할 때 처음에는 ```total/2 < i```로 비교했습니다.
	- 하지만 이 코드는 total의 짝수와 홀수에 따라 다른 결과를 가지고 오기 때문에 적합하지 않은 코드였습니다.

많이 틀린 만큼 다음에는 이런 유형의 문제에서 실수를 하지 않고 문제를 풀고 싶습니다....^^,,

