### PR TITLE
[BOJ]25186. INFP 두람

### DIFF
--- a/soomin_kim/BOJ_25186.java
+++ b/soomin_kim/BOJ_25186.java
@@ -1,0 +1,29 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.StringTokenizer;
+
+public class BOJ_25186 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        long max = 0;
+        long sum = 0;
+        for(int i = 0; i<n; i++){
+            int cloth = Integer.parseInt(st.nextToken());
+            max = Math.max(max, cloth);
+            sum += cloth;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        if(max > sum-max && sum != 1) sb.append("Unhappy");
+        else sb.append("Happy");
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 25186번 INFP 두람 문제를 풀었습니다.


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/48270067/0e474d91-af3d-41aa-a0f1-fe451c24e91c)



## 📝 Review Note
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/48270067/0e83b2b1-4afe-4f0f-a9d7-c317f245a485)

처음엔 문제만 보고 양옆의 사람과 계속 비교하면서 n만큼 반복하는 줄 알았는데 아니었습니다. 
다른 분들께 약간의 힌트를 받아서 접근했습니다.

무조건 안되는 경우가 있으면 unhappy를 출력하였습니다. 처음 배열에 각 옷의 개수를 입력 받아 저장할 때 최대 개수를 구했습니다. 또 전체 인원을 구하기 위해서 `sum`변수에 전체 인원을 더해주었습니다.

만약에 최대 개수가 나머지 개수보다 크다면 이웃한 사람과 같은 옷을 입게 됩니다. (퐁당퐁당을 생각해보자) 그러므로 unhappy 를 출력해줍니다. `(max > sum - max ) `

계속 88, 99에서 틀렸는데 혼자 여행 간 경우를 제가 잘 고려한 줄 알았는데 엉성하게 해서 생긴 문제였습니다.

다들 수고하셨습니다.