### PR TITLE
[BOJ] 25186. INFP 두람

### DIFF
--- a/황윤정/BOJ25186.java
+++ b/황윤정/BOJ25186.java
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ25186 {
+    static int N; // 옷 종류의 수
+    static int[] clothes; // 종류별 옷 개수
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        clothes = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<N; i++) {
+            clothes[i] = Integer.parseInt(st.nextToken());
+        }
+        long sum = 0;
+        for(int i=0; i<N; i++) {
+            sum += clothes[i]; // 종류별 옷 개수의 합
+        }
+        for(int i=0; i<N; i++) {
+            // 혼자인 경우 옷이 겹칠 수 없으므로 옷의 총 개수가 1보다 크면서
+            // 총 개수의 절반이 넘는 옷이 있다면
+            if(sum > 1 && clothes[i] > sum/2) {
+                System.out.println("Unhappy"); // 행복할 수 없다 출력하고
+                return; // 바로 종료
+            }
+        }
+        System.out.println("Happy"); // 모든 옷의 개수가 총합의 절반을 넘지 않는 경우
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 25186. INFP 두람 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/79037963/5820af87-21e0-4610-adaf-4d4dd09e8327)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
N가지 옷 중에서 개수가 옷 총합의 절반을 넘는 옷이 있다면 이웃한 사람과 옷이 안 겹치는 경우를 만들어 낼 수 없으므로 바로 Unhappy를 출력하고, 모든 옷이 총합의 절반을 넘지 않는다면 Happy를 출력하도록 했습니다.


처음에는 양 옆에 사람과 옷이 같으면 안되니까 현재 인덱스+3 마다 개수가 많은 옷부터 배열에 넣어볼까 생각했습니다.
하지만 옷의 총 개수가 int 범위를 넘을 정도면 배열 인덱스가 엄청 커질 것 같아서 다른 방법을 생각했습니다.
Unhappy를 출력하는 예제에서 보이는건, 옷 총합의 절반을 넘는 옷이 있다는 겁니다.
다른 방법은 생각이 나지않아서 일단 총합의 절반을 넘는 옷이 있을 때 거르는 방법을 시도했습니다.

혼자일 때 옷의 개수는 총합의 절반을 넘지만 겹치지 않으므로, 구현하다 이 경우를 처리해주면서 뭔가 문제가 잘 풀린다고 생각했지만...틀렸습니다! 이유는 옷의 개수가 총합을 넘는지 체크할 때 초과가 아니라 이상으로 처리했기 때문입니다. (예시 N=2, 종류별 옷 개수는 1 1 일 때 Happy 떠야함)
그래서 등호를 없애니 맞았습니다.  뭔가 야매로 풀어낸 것 같지만 생각보다 빨리 풀어서 좋습니다.
