### PR TITLE
[BOJ] 4889. 안정적인 문자열

### DIFF
--- a/남동우/BOJ4889.java
+++ b/남동우/BOJ4889.java
@@ -1,0 +1,41 @@
+import java.io.*;
+import java.util.Stack;
+
+public class BOJ4889 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int caseCount = 0;
+        while(true){
+            String input = br.readLine();
+            if(input.contains("-")){ // - 가 포함된 입력을 받으면 while 문을 탈출합니다.
+                break;
+            }
+
+            caseCount++;
+            System.out.printf("%d. %d\n", caseCount, getStableString(input));
+        }
+    }
+    static int getStableString(String input){
+        Stack<Character> stack = new Stack<>();
+        for(char c : input.toCharArray()){
+            if(!stack.isEmpty() && stack.peek() == '{' && c == '}'){
+              // 스택이 비어있지 않으면서, stack 맨 위가 열려 있고, 새로 받는 것이 닫는 괄호이면
+              // 스택에서 하나를 뺍니다. 위의 조건에 만족하지 않으면, 스택에 하나를 더합니다.
+                stack.pop();
+            }else{
+                stack.add(c);
+            }
+        }
+        int count = 0;
+        while(!stack.isEmpty()){
+            char element = stack.pop(); // 스택에서 하나를 뺍니다.
+            if(element == '{' && stack.peek() == '}'){ 
+              // 스택에서 뺀 요소가 '{' 이면서 맨 위 요소가 '}' 이면 미리 하나 늘려 줍니다.
+                count++;
+            }
+            stack.pop(); // 나머지는 }} 아니면 {{ 같은 요소입니다. 하나 더 빼고 카운트를 하나 늘려 줍니다.
+            count++;
+        }
+        return count; // 도출된 count 를 return 합니다.
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
 백준 4889번, 안정적인 문자열 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/c1134f0d-96ef-41f7-adb4-4f0f43f7c154)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

대표적인 스택 문제를 한번 가져와 보았습니다. 스택 맨 위가 여는 괄호이고 그 다음 넣을 요소가 닫는 괄호라면, 안정적인 괄호 조합이므로 스택에서 맨 위를 뺍니다. 위의 조건에 해당하지 않는다면, 일단 스택에 모두 넣어 줍니다. 이런 방식으로 문자열을 모두 순회하면 여는 괄호나 닫는 괄호만 존재하거나, } { 와 같은 케이스가 괄호 쌍으로 존재합니다. 닫는괄호 - 여는괄호 페어가 스택에 존재하면 + 2 처리하고, 나머지는 둘중 하나만 바꾸면 되므로 +1 하며 바꿔야 할 괄호 갯수를 세어 주면 됩니다.

문자열 태그 문제는 많이 나오는 문제는 아닙니다만, 맨날 푸는 문제 유형을 한번 피해 보기 위해 가져와 보았습니다 ^^ 
