### PR TITLE
[BOJ] 15989. 1, 2, 3 더하기 4

### DIFF
--- a/이수민/BOJ_15989.java
+++ b/이수민/BOJ_15989.java
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class BOJ_15989 {
+
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        int[] dp = new int[10001];
+
+        // 전처리 값들
+        dp[0] = dp[1] = 1;
+        dp[2] = 2;
+        dp[3] = 3;
+
+        for(int i=4; i<10001; i++){
+            dp[i] = dp[i-1] + dp[i-2] - dp[i-3]; // 점화식
+            if (i%3==0) dp[i]++; // i가 3의 배수인 경우
+        }
+
+        for(int t=0; t<T; t++)
+            sb.append(dp[Integer.parseInt(br.readLine())]).append("\n");
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 15989번 1, 2, 3 더하기 4 문제를 풀었습니다. 


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/10d64456-b5f4-464c-a8b6-53d36e85433d)


## 📝 Review Note
자신보다 1, 2가 작은 수의 경우의 수를 이용하여 풀 수 있었습니다. 
점화식은 다음과 같이 세웠습니다. ```dp[i] = dp[i-1] + dp[i-2] - dp[i-3]```

5를 예로 들 때, 5보다 1, 2가 작은 수인 4와 3을 이용하여 4+1와 3+2인 경우를 고려하려고 합니다.
dp[i-1]인 4의 경우의 수는 4개이고,
dp[i-2]인 3의 경우의 수는 3개입니다.
그러나 4에 1을 더하고 3에 2를 더하는 과정에서 [1+2+2, 1+1+1+2]와 같이 중복되는 경우가 dp[i-3]만큼 나타납니다. 이 중복을 제거하기 위해 -dp[i-3]를 해주었습니다.

또한, 6에서는 3+3, 9에서는 3+3+3 과 같이 3의 배수자리에서는 '3'만을 이용해 정수를 표현할 수 있으므로 추가로 1을 더해줬습니다.

점화식 도출하는데 너무 너무 오랜 시간이 걸렸습니다......🥲🥲 dp는 어려워요 흙