### PR TITLE
[BOJ] 1946. 신입 사원

### DIFF
--- a/이수민/BOJ_1946.java
+++ b/이수민/BOJ_1946.java
@@ -1,0 +1,58 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+// 지원자의 성적 순위를 정보를 갖는 클래스
+class Applicant implements Comparable<Applicant>{
+	int document;
+	int interview;
+	
+	Applicant(int document, int interview){
+		this.document = document;
+		this.interview = interview;
+	}
+
+	// 서류 심사 성적을 토대로 정렬
+	public int compareTo(Applicant o) {
+		return Integer.compare(this.document, o.document);
+	}	
+}
+
+public class BOJ_1946 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = null;
+		StringBuilder sb = new StringBuilder();
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int t=0; t<T; t++) {
+			int n = Integer.parseInt(br.readLine());
+			PriorityQueue<Applicant> applicants = new PriorityQueue<>();
+
+			for(int i=0; i<n; i++) {
+				st = new StringTokenizer(br.readLine());
+				applicants.offer(new Applicant(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())));
+			}
+
+			int result = 0;
+			int highGrade=n; // 현재 가장 높은 면접 순위를 저장
+			while(!applicants.isEmpty()) {
+				// 현재 지원자의 면접 성적 순위
+				int curGrade = applicants.poll().interview;
+				
+				// 현재 순위가 이제까지 순위들보다 더 높다면
+				if (curGrade <= highGrade) {
+					result++;
+					highGrade = curGrade; // 값을 갱신
+				}
+			}
+			
+			sb.append(result).append("\n");
+		}
+		
+		System.out.println(sb);
+		
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 1946번 신입 사원 문제를 풀었습니다.


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/d153ff2a-1727-474b-9e26-4f028340b61f)


## 📝 Review Note
처음에는 동석차가 없다는 설명을 제대로 보지 않아서, 서류와 면접 전형의 순위를 따로 보는 풀이를 생각했습니다. 그러나 이 방식은 질문게시판의 반례를 통과하지 못했고, 통과했더라도 시간 초과에 걸릴 것 같아 다른 방법을 고민하다가 동석차가 없다는 설명을 읽게 되었습니다.

동석차가 없고 비교해야 할 전형도 두 개 밖에 없었기 때문에, 우선 서류 전형을 순위의 오름차순으로 정렬하였습니다. 이후 면접 전형의 순위를 이전까지의 면접전형 순위의 최솟값과 비교하면서, 그보다 크다면 서류전형도 면접전형도 이전 지원자를 이기지 못하기 때문에 result와 면접전형 값갱신을 하지 않도록 설정했습니다.

맨날 문제 제대로 안 읽고 풀어서 삽질을 열심히 하는 것 같습니다....😢