### PR TITLE
[BOJ] 1946. 신입 사원

### DIFF
--- a/황윤정/BOJ1946.java
+++ b/황윤정/BOJ1946.java
@@ -1,0 +1,53 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ1946 {
+    static int T, N, result; // 테스트케이스 수, 지원자 수, 신입사원 수
+    static Grade[] arr; // 지원자 성적 저장
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+
+        T = Integer.parseInt(br.readLine());
+        for(int t=0; t<T; t++) {
+            result = 1; // 1등은 무조건 채용
+            N = Integer.parseInt(br.readLine());
+            arr = new Grade[N];
+            for(int i=0; i<N; i++) {
+                st = new StringTokenizer(br.readLine());
+                int docu = Integer.parseInt(st.nextToken());
+                int inter = Integer.parseInt(st.nextToken());
+                arr[i] = new Grade(docu, inter);
+            }
+            Arrays.sort(arr); // 서류심사 성적순으로 정렬
+            int rank = arr[0].interview; // 현재 면접 성적 최고 순위
+            for(int i=1; i<N; i++) {
+                if(arr[i].interview < rank) { // 면접 성적 순위가 더 높으면
+                    rank = arr[i].interview; // 면접 최고 순위 갱신
+                    result++; // 선발 가능한 신입사원 수 증가
+                }
+            }
+            sb.append(result+"\n");
+        }
+        System.out.println(sb.toString());
+    }
+}
+
+class Grade implements Comparable<Grade>{
+    int document; // 서류심사 성적
+    int interview; // 면접 성적
+
+    public Grade(int document, int interview) {
+        this.document = document;
+        this.interview = interview;
+    }
+
+    @Override
+    public int compareTo(Grade o) {
+        return this.document - o.document; // 서류심사 오름차순 정렬
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1946. 신입 사원 문제를 해결했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/79037963/b6979fa4-370c-4cb9-817e-4bc94188c7fb)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음에 각 기준 별로 정렬을 하려고 했는데 계속 N^2에서 벗어날 수 없었습니다. N^2이면 무조건 시간초과가 날 겁니다.
그래서 정렬 기준 하나만 선택해서 데이터를 정렬했습니다. 저 같은 경우에는 서류심사 성적을 기준으로 하였습니다.
먼저 서류심사 성적을 오름차순(숫자가 작아야 순위가 높음)으로 정렬하였습니다. 그리고 면접 성적 최고 순위를 저장해서 이 값보다 더 높은 면접 성적 순위가 나오면 갱신시키고 채용 가능한 인원 수를 증가 시켰습니다.
이렇게 하면 서류 성적 순위가 낮아도 면접 순위가 높아서 합격 시킬 수 있습니다.

역시 그리디는 아이디어 떠올리는게 어렵네요..!