### PR TITLE
[BOJ] 12761. 돌다리

### DIFF
--- a/남동우/BOJ12761.java
+++ b/남동우/BOJ12761.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ12761 {
+    static final int MAX_VALUE = Integer.MAX_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        int aCong = Integer.parseInt(st.nextToken());
+        int bCong = Integer.parseInt(st.nextToken());
+
+        int current = Integer.parseInt(st.nextToken());
+        int dest = Integer.parseInt(st.nextToken());
+
+        Queue<Integer> queue = new ArrayDeque<>();
+        int[] jumpCount = new int[100_001]; // jumpCount 를 저장할 배열을 만듭니다.
+
+        Arrays.fill(jumpCount, MAX_VALUE); // 초기 jumpCount 를 Integer 최대값으로 저장하고
+        jumpCount[current] = 0; // 현재 점프카운트는 0으로 만들어 줍니다.
+        queue.add(current); // 그리고 queue 에도 넣어 줍니다.
+        int[] justGoArray = new int[]{aCong, -1 * aCong, bCong, -1 * bCong, 1, -1};
+        int[] jumpArray = new int[]{aCong, bCong}; 
+      // 노가다를 줄여주기 위해, 어디로 단순히 갈 수 있는지, 몇 배로 점프할 수 있는지
+      // 배열을 만들어 줍니다.
+
+        while(!queue.isEmpty() && jumpCount[dest] == MAX_VALUE){
+            int position = queue.remove();
+
+            for(int cong : jumpArray){
+                if(canPowerJump(jumpCount, position, cong)){ 
+                  // 배열 범위 안이면서도, 가고자 하는 곳이 현재 position 의 jumpCount + 1 보다 
+                  // 크다면, 업데이트 대상입니다. jumpCount 를 더 작게 업데이트 해주고, 
+                  // queue 에도 집어 넣어 줍니다.
+                    jumpCount[position * cong] = jumpCount[position] + 1;
+                    queue.add(position * cong);
+                }
+            }
+
+            for(int cong : justGoArray){
+                if(canJustGo(jumpCount, position, cong)){
+                  // 위 조건 그대로 판별해주고, 판별 결과 업데이트 대상이면
+                  // jumpCount 를 더 작게 업데이트 해주고, queue 에도 집어 넣어 줍니다.
+                    jumpCount[position + cong] = jumpCount[position] + 1;
+                    queue.add(position + cong);
+                }
+            }
+        }
+
+        System.out.println(jumpCount[dest]);
+    }
+  // x 배 점프해서 갈 수 있는지 여부를 돌려줍니다.
+    static boolean canPowerJump(int[] count, int position, int toJump){
+        return (position * toJump) < count.length
+                && count[position * toJump] > count[position] + 1;
+    }
+  // 이동해 갈 수 있는지 여부를 돌려줍니다.
+    static boolean canJustGo(int[] count, int position, int toGo){
+        return 0 <= (position + toGo) && (position + toGo) < count.length
+                && count[position + toGo] > count[position] + 1;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 12761번, 돌다리 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/8fce2c79-adf3-49c0-b975-36ddae8af95d)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
문제를 보자마자, BFS 냄새가 너무 나서 바로 BFS로 문제를 바라보기 시작했습니다. 시간 초과가 날 것이 우려되어, 가장 최악의 케이스가 어떻게 나올지 살펴보았습니다. 이미 방문한 곳에 다시 가지만 않게 해 주면 최대 10만 번 정도 돌 것이고, BFS 에서 지금 가고자 하는 곳이 현재 포지션의 점프횟수 + 1 보다 클 때만 업데이트 하게 해 준다면, 중복해서 방문할 일이 없다고 생각했습니다. 

충분히 BFS로 해결 가능했던 문제라, 바로 문제에 착수해서 문제를 풀었지만, 몇 번 정도 틀렸다고 나왔습니다. 원인을 살펴보니, 단순히 +1, -1 을 갈 수 있다는 것을 빠뜨린 것이 문제였습니다. 그 부분을 잡아주니 맞았다고 나왔습니다. 항상 느끼는 것이지만, 꼼꼼하게 문제를 보아야 하는데 그것이 잘 안되는 것 같습니다 ㅎㅎ  