### PR TITLE
[BOJ] 1802. 종이 접기

### DIFF
--- a/이수민/BOJ_1802.java
+++ b/이수민/BOJ_1802.java
@@ -1,0 +1,38 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class BOJ_1802 {
+
+    static char[] paper;
+    private static boolean check(int start, int end){
+        if (start == end) return true; // 길이가 1인 경우
+
+        int mid = (start+end)/2;
+
+        // mid를 기준으로 양쪽의 범위를 늘려가면서 확인
+        for(int i=start; i<mid; i++){
+            // 현재 보는 위치들의 값이 같다면, 접을 수 없음
+            if (paper[i] == paper[end-i]) return false;
+        }
+
+        // mid를 기준으로 나눈 종이의 접은 흔적 살핌
+        return check(start, mid-1) && check(mid+1, end);
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine());
+        for(int t=0; t<T; t++){
+            paper = br.readLine().toCharArray();
+
+            if (check(0, paper.length-1)) // 접을 수 있음
+                sb.append("YES").append("\n");
+            else
+                sb.append("NO").append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}

--- a/이수민/BOJ_19638.java
+++ b/이수민/BOJ_19638.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_19638 {
+
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int h = Integer.parseInt(st.nextToken());
+        int t = Integer.parseInt(st.nextToken());
+
+        // 거인을 키 순서대로 정렬
+        PriorityQueue<Integer> heights = new PriorityQueue<>((o1, o2) -> o2 - o1);
+        for(int i=0; i<n; i++)
+            heights.offer(Integer.parseInt(br.readLine()));
+
+        int used = 0; // 뿅망치를 사용한 횟수
+
+        while(used < t){
+            int tallest = heights.peek();
+
+            // 제일 큰 거인이 센티보다 작은 경우 - 모든 거인이 센티보다 작음
+            // 가장 큰 거인이 1이라면, 센티가 더 커질 수 있는 경우가 없음
+            if (tallest < h || tallest == 1) break;
+
+            // 제일 큰 거인이 센티보다 크거나 같으면, 거인의 키를 반으로 나누어 큐에 다시 넣는다.
+            heights.offer(heights.poll()/2);
+            ++used; // 뿅망치 사용횟수 증가
+
+        }
+
+        System.out.println(h > heights.peek() ? "YES\n"+used : "NO\n"+heights.poll());
+
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 1802번 종이 접기 문제를 풀었습니다.


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/75559067/e56cddde-7ab5-41f0-9f5e-d89337cc875f)


## 📝 Review Note
각각의 종이를 동호의 방법대로 접기 위해서는 더 이상 접을 수 없을 때까지 즉, 나눈 종이가 1이 될 때까지 종이가 대칭을 유지해야합니다.
종이의 중간부분을 기준으로 하여 왼쪽 오른쪽 부분이 대칭을 이룰 수 있는지 판단할 수 있도록 했습니다. 현재 mid를 기준으로 대칭을 이룰 수 없다면 곧바로 false를 해서 더이상 작은 범위를 살피지 않도록 했습니다. 반대로 대칭을 이룰 수 있다면 더 작은 범위를 살피며 더 작은 범위 또한 접을 수 있는지 확인하게 했습니다.

mid를 기준으로 종이의 대칭이 필요하다는 아이디어를 생각해 내는데 많은 시간을 쓴 문제였습니다. 접고 굴리고 하는 문제는 역시 어려운 것 같아요 흙