### PR TITLE
[BOJ] 1802. 종이 접기

### DIFF
--- a/현수연/BOJ1802.java
+++ b/현수연/BOJ1802.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ1802 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		// 테스트 케이스
+		for(int test_case=0;test_case<T;test_case++) {
+			char in[] = br.readLine().toCharArray(); // OUT IN 입력
+			int mid = in.length/2; // 정중앙 index 값
+			boolean isPossible= true; // 종이 접기로 가능한지 여부 값
+			// 마지막 접기 부분까지 반복
+			while(mid>0) {
+				// 중앙 부분을 기준으로 양옆이 다른 방향으로 접혔는지 검토
+				for(int i=1;i<=mid;i++) {
+					// 만일 같은 방향으로 접혔을 경우 종이접기 불가능 및 break
+					if(in[mid-i]==in[mid+i]) {
+						isPossible=false;
+						break;
+					}
+				}
+				// 검토를 마친 후 한 번 접은 다음의 종이접기가 가능한지 검토를 위해 mid값 갱신
+				mid/=2;
+				// 이미 종이접기가 불가능할 경우 break
+				if(!isPossible)
+					break;
+			}
+			// 최종으로 가능여부 출력
+			if(isPossible)
+				sb.append("YES\n");
+			else
+				sb.append("NO\n");
+		}
+		System.out.println(sb);
+	}
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
종이 접기 문제를 풀었습니다!!
 종이를 먼저 한 번 접고 그 다음에 접을 때부터는 해당 접은 부분을 중심으로 양옆이 다른 방향으로 접힌다는 점을 이용했습니다. 이 부분은 처음 접을 때를 제외하고 모두 적용이 되기 때문에 접은 횟수만큼 계속해서 중앙을 기준으로 양옆을 검토했습니다.
 분할 검토를 진행하면서 한 번이라도 같은 방향으로 접혀있는 경우 안된다고 판단하고 `break`처리 후 불가능 하다는 `false` 값을 부여해주었고, 모두 검토했는데도 `break`되지 않았을 경우  `true`값을 유지하여 해당 boolean값을 통해 최종적인 출력을 내주었습니다.

## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/81295902/54c65da4-571b-4122-a4c0-26959dbd3826)
채점 결과입니덩


## 📝 Review Note
전 단순 그리디 로직인줄 알았는데 문제를 다 풀고 봤을 때 분할정복임을 알았습니당,,, 분할정복 어렵군뇨 열심히 공부해야겠어요!!!!!!!!

