### PR TITLE
[BOJ] 27172. 수 나누기 게임

### DIFF
--- a/임수빈/boj27172.java
+++ b/임수빈/boj27172.java
@@ -1,0 +1,42 @@
+import java.io.*;
+import java.util.*;
+
+public class boj27172 {
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		
+		int MAX_SIZE = 1000001;
+		
+		int n = Integer.parseInt(br.readLine());
+		int[] cards = new int[n]; // 각 플레이어가 가지고 있는 카드에 적힌 수
+		boolean[] visited = new boolean[MAX_SIZE]; // 방문 체크 배열
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i=0; i<n; i++) {
+			cards[i] = Integer.parseInt(st.nextToken());
+			visited[cards[i]] = true;
+		}
+		
+		int[] answer = new int[MAX_SIZE];
+		
+		for (int card: cards) {
+			// 각 플레이어의 카드에 적힌 수의 배수 확인
+			for (int j=card*2; j<MAX_SIZE; j+=card) {
+				// 카드 존재하는 경우 -> 현재 플레이어 승리, 상대 플레이어 패배
+				if (visited[j]) {
+					answer[card]++;
+					answer[j]--;
+				}
+			}
+		}
+		
+		// 출력
+		for (int card: cards) {
+			sb.append(answer[card]).append(" ");
+		}
+		System.out.println(sb);
+	}
+
+}


### PR DESCRIPTION
## 👩‍💻 Contents
- 백준 27172: 수 나누기 게임


## 📱 Screenshot
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/66028419/045b7514-cdf0-467b-b327-8cbd2edc25ec)


## 📝 Review Note
시도 1. 2차원 정답 배열 + 2차원 visited 배열
```java
int[][] result = new int[n][n];
boolean[][] visited = new boolean[n][n];
		
for (int i=0; i<n; i++) {
	int sum = 0;
	for (int j=0; j<n; j++) {
		if (i == j) {
			continue;
		}
				
		if (visited[i][j]) {
			sum += result[i][j];
			continue;
		}
				
		visited[i][j] = true;
		visited[j][i] = true;
		if (cards[j] % cards[i] == 0) {
			result[i][j]++;
			result[j][i]--;
		}
		sum += result[i][j];
	}
			
	sb.append(sum).append(" ");
}
```
풀면서도 이게 맞나 했는데 메모리 초과를 당했구요,,

시도 2. 1차원 정답 배열 + 2차원 visited 배열
```java
int[] answer = new int[n];
boolean[][] visited = new boolean[n][n];
		
for (int i=0; i<n; i++) {
	int sum = 0;
	for (int j=0; j<n; j++) {
		if (i == j) {
			continue;
		}
				
		if (visited[i][j]) {
			continue;
		}
				
		visited[i][j] = true;
		visited[j][i] = true;
		if (cards[j] % cards[i] == 0) {
			answer[i]++;
			answer[j]--;
		}
		sum += result[i][j];
	}
			
	sb.append(sum).append(" ");
}
```
result 배열을 1차원 배열로 바꿔서 시도해봤으나 역시 또 메모리 초과를 당했구요,,,

시도 3. 1차원 정답 배열
```java
int[] answer = new int[n];
		
for (int i=0; i<n; i++) {
	for (int j=0; j<n; j++) {
		if (i == j) {
			continue;
		}
				
		if (cards[j] % cards[i] == 0) {
			answer[i]++;
			continue;
		}
				
		if (cards[i] % cards[j] == 0) {
			answer[i]--;
		}
	}
			
	sb.append(answer[i]).append(" ");
}
		
System.out.println(sb);
```
visited 배열을 없애니 역시나,,, 시간 초과를 당했구요 ^0^

시도 4. 결국 해결 방법은,,,
최대 사이즈의 visited 배열을 만들어서 각 카드 방문 표시를 해주고
각 플레이어의 카드에 적힌 수의 배수를 확인하면서 visited = true이면 (나누어 떨어지는 경우)
현재 플레이어의 정답을 +1, 상대 플레이어의 정답을 -1 해주었습니당...
쉬운 듯 하면서 힘드네요ㅠ
