### PR TITLE
[BOJ] 1504. 특정한 최단 경로

### DIFF
--- a/남동우/BOJ1504.java
+++ b/남동우/BOJ1504.java
@@ -1,0 +1,66 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ1504 {
+    static final int INF = Integer.MAX_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        int vertexCount = Integer.parseInt(st.nextToken());
+        int edgeCount = Integer.parseInt(st.nextToken());
+
+        long[][] matrix = makeMatrix(br, vertexCount, edgeCount);
+      // 시작점, 종료 지점, weight 정보를 입력받아 2차원 배열을 만듭니다. 
+      // 정점 갯수가 최대 800개이므로, 충분히 메모리 초과가 나지 않을 것이라 생각하여
+      // 인접 matrix 를 만들어 줍니다. 
+
+      
+      // floyd-warshall 알고리즘을 수행해, 모든 임의의 정점에서 다른 정점으로 가는
+      // 최소 거리를 만들어 줍니다.
+        for(int k = 1; k < matrix.length; k++){
+            for(int i = 1; i < matrix.length; i++){
+                for(int j = 1; j < matrix.length; j++){
+                    if(matrix[i][j] > matrix[i][k] + matrix[k][j]){
+                        matrix[i][j] = matrix[j][i] = matrix[i][k] + matrix[k][j];
+                    }
+                }
+            }
+        }
+
+      // 꼭 지나야 하는 지점을 입력받습니다.
+        st = new StringTokenizer(br.readLine()," ");
+        int passOne = Integer.parseInt(st.nextToken());
+        int passTwo = Integer.parseInt(st.nextToken());
+
+      // passOne, passTwo 를 지나 마지막 점으로 가는 점과, passTwo, passOne 순으로 지나 마지막 점으로
+      // 가는 거리를 만들어 줍니다.
+        long rootOne = matrix[1][passOne] + matrix[passOne][passTwo] + matrix[passTwo][matrix.length - 1];
+        long rootTwo = matrix[1][passTwo] + matrix[passTwo][passOne] + matrix[passOne][matrix.length - 1];
+
+      // 둘 중 최소를 result 로 만들어 줍니다. 이때, 최소값이 INF 보다 크거나 같다면, 가는 것이 불가능한
+      // 케이스입니다. 
+      // 가는 것이 불가능한 케이스는 -1, 아니면 결과를 출력합니다.
+        long result = Math.min(rootOne, rootTwo);
+        System.out.println(result >= INF ? -1 : result);
+    }
+    static long[][] makeMatrix(BufferedReader br, int vertexCount, int edgeCount) throws IOException {
+        long[][] matrix = new long[vertexCount + 1][vertexCount + 1];
+        for(int i = 1; i < matrix.length; i++){
+            Arrays.fill(matrix[i], INF);
+            matrix[i][i] = 0;
+        }
+
+        for(int i = 0; i < edgeCount; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine()," ");
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            if(matrix[a][b] > weight){
+                matrix[a][b] = matrix[b][a] = weight;
+            }
+        }
+        return matrix;
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
백준 1504번, 특정한 최단 경로 문제를 해결합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/SSAFY-5959-STUDY/Algorithm/assets/96509257/13cd1912-395b-4537-b2ec-417468d5b091)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
처음 문제를 마주했을 때, 다익스트라를  두 번 정도 쓰면 되겠다는 생각을 했습니다. 하지만, 첫번째 지점을 갈 때 두번째 지점을 먼저 가는 것에 대해 예외를 생각해야 할 뿐 아니라 다른 보이지 않는 예외까지 모두 처리해야 한다는 생각에 머리가 아팠습니다.

그런데, 싸피 알고리즘 주간 거의 마지막 즈음에 총 연산횟수가 1억이 넘어가는데도 불구하고 플로이드 워셜  알고리즘을 적용해 통과를 받았던 수업 내용이 기억이 났습니다. 정확히 왜 그런지는 몰라도, 이번 케이스에서도 적용이 가능할까 싶어 한번 저도 도박수를 걸어 보고 싶다는 생각이 들었습니다. O(N^3) 인 알고리즘이고, 그런 이유로 총 연산이 최악의 경우 5억번이 넘어가는 사태가 일어나는 것 같았지만, 결정적으로 구현이 너무 단순했기 때문에 그냥 질러보기로 했습니다. 

도박수가 제대로 통해서 AC(Accept) 를 받을 수 있었고, 여러 아는 분들께 자문을 구한 결과 C언어를 기준으로 1초 안에 7억 번까지는 무난히 돌아간다는 결과(?)(뇌피셜?) 도 받을 수 있었습니다. 메모리 캐싱으로 인한 시간 단축 & TLB Hit 와 같은 다양한 이유로 위와같은 결론이 도출되는 것 같습니다. 

Java 기준으로도, 1초에 3억 번 정도 연산이 돌아가는 것 같습니다! 자바는 C언어 기준인 백준 시간에서 ×2 +  0.5s 정도의 어드벤티지를 받기 때문에, 다른 보시는 분들께서도 이를 유념에 두고 플로이드 워셜 알고리즘을 시도해 보셔도 좋을 것 같습니다!
